### PR TITLE
Remove undocumented SystemGroup option

### DIFF
--- a/root/etc/e-smith/templates/etc/cups/cupsd.conf/70AdminSystemGroup
+++ b/root/etc/e-smith/templates/etc/cups/cupsd.conf/70AdminSystemGroup
@@ -1,3 +1,0 @@
-
-SystemGroup { $cupsd{SystemGroup} || "admin" }
-


### PR DESCRIPTION
Avoid errors when upgrading to `cups-1.6.3-29`:
%post scriptlet moves SystemGroup to cups-files.conf
generating an invalid configuration.