### PR TITLE
Samba printers must be in global section

### DIFF
--- a/root/etc/e-smith/templates/etc/samba/smb.conf/50printers
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/50printers
@@ -1,3 +1,6 @@
+#
+# 50printers must be in global section and before service section
+#
 {
    my $useCups = $smb{'UseCups'} || 'disabled';
    if ($useCups eq 'enabled') {

--- a/root/etc/e-smith/templates/etc/samba/smb.conf/70printers
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/70printers
@@ -1,6 +1,7 @@
 {
    my $useCups = $smb{'UseCups'} || 'disabled';
    if ($useCups eq 'enabled') {
+       $OUT .= "[global]\n";
        $OUT .= "printing = cups\n";
        $OUT .= "printcap name = cups\n\n";
        $OUT .= "[printers]\n";
@@ -14,6 +15,7 @@
        $OUT .= $smb{UseClientDriver} || "yes";
    } else {
        $OUT .= "# Cups is disabled\n"; 
+       $OUT .= "[global]\n";
        $OUT .= "printcap name = /etc/printcap\n";
        $OUT .= "load printers = no\n";
    }

--- a/root/etc/e-smith/templates/etc/samba/smb.conf/70printers
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/70printers
@@ -1,6 +1,3 @@
-#
-# 50printers must be in global section and before service section
-#
 {
    my $useCups = $smb{'UseCups'} || 'disabled';
    if ($useCups eq 'enabled') {


### PR DESCRIPTION
We have a warning when the esmith `$smb{HomeAdmStatus}` is set to enabled because the template `/etc/e-smith/templates/etc/samba/smb.conf/60homeadmins` is expanded before the cups template

https://github.com/NethServer/dev/issues/6543